### PR TITLE
Add parser to generate names.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ parsers.parseCompositionExclusions = require('./scripts/parse-composition-exclus
 parsers.parseLineBreak = require('./scripts/parse-line-break.js');
 parsers.parseScriptExtensions = require('./scripts/parse-script-extensions.js');
 parsers.parseWordBreak = require('./scripts/parse-word-break.js');
+parsers.parseNames = require('./scripts/parse-names.js');
 const extend = utils.extend;
 const cp = require('cp');
 const jsesc = require('jsesc');
@@ -117,6 +118,12 @@ const generateData = function(version) {
 		'version': version,
 		'map': parsers.parseWordBreak(version),
 		'type': 'Word_Break'
+	}));
+	console.log('Parsing Unicode v%s `Names`…', version);
+	extend(dirMap, utils.writeFiles({
+		'version': version,
+		'map': parsers.parseNames(version),
+		'type': 'Names'
 	}));
 	// Sort array values.
 	Object.keys(dirMap).forEach(function(property) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ parsers.parseCompositionExclusions = require('./scripts/parse-composition-exclus
 parsers.parseLineBreak = require('./scripts/parse-line-break.js');
 parsers.parseScriptExtensions = require('./scripts/parse-script-extensions.js');
 parsers.parseWordBreak = require('./scripts/parse-word-break.js');
-parsers.parseNames = require('./scripts/parse-names.js');
+parsers.parseName = require('./scripts/parse-name.js');
 const extend = utils.extend;
 const cp = require('cp');
 const jsesc = require('jsesc');
@@ -119,11 +119,11 @@ const generateData = function(version) {
 		'map': parsers.parseWordBreak(version),
 		'type': 'Word_Break'
 	}));
-	console.log('Parsing Unicode v%s `Names`…', version);
+	console.log('Parsing Unicode v%s `Name`…', version);
 	extend(dirMap, utils.writeFiles({
 		'version': version,
-		'map': parsers.parseNames(version),
-		'type': 'Names'
+		'map': parsers.parseName(version),
+		'type': 'Name'
 	}));
 	// Sort array values.
 	Object.keys(dirMap).forEach(function(property) {

--- a/scripts/parse-name.js
+++ b/scripts/parse-name.js
@@ -21,11 +21,6 @@ const parseName = function(version) {
 			if (flag) {
 				if (/<.+, Last>/.test(name)) {
 					flag = false;
-					const rangeName = /<(.+), Last>/.exec(name)[1];
-
-					utils.range(first, codePoint).forEach(function (value) {
-						utils.append(map, rangeName, value);
-					});
 				} else {
 					throw Error('Database exception');
 				}
@@ -36,8 +31,10 @@ const parseName = function(version) {
 				} else {
 					const oldName = data[10];
 
-					if (/<control>/.test(name) && oldName !== "") {
-						utils.append(map, oldName, codePoint);
+					if (/<control>/.test(name)) {
+						if (oldName !== "") {
+							utils.append(map, oldName, codePoint);
+						}
 					} else {
 						utils.append(map, name, codePoint);
 					}

--- a/scripts/parse-name.js
+++ b/scripts/parse-name.js
@@ -18,27 +18,29 @@ const parseName = function(version) {
 		const name = data[1];
 
 		if (!isNaN(codePoint)) {
-			if (flag) {
-				if (/<.+, Last>/.test(name)) {
-					flag = false;
+			var match = /<([^>]+)>/.exec(name);
+
+			if (match) {
+				const rangeName = /(.+), (First|Last)/.exec(match[1]);
+
+				if (rangeName) {
+					if (flag && rangeName[2] === 'Last') {
+						flag = false;
+
+						utils.range(first, codePoint).forEach(function (value) {
+							utils.append(map, rangeName[1] + ' ' + utils.codePointToHex(value), value);
+						});
+					} else if (!flag && rangeName[2] === 'First') {
+						flag = true;
+						first = codePoint;
+					} else {
+						throw Error('Database exception');
+					}
 				} else {
-					throw Error('Database exception');
+					utils.append(map, match[1] + ' ' + utils.codePointToHex(codePoint), codePoint);
 				}
 			} else {
-				if (/<.+, First>/.test(name)) {
-					flag = true;
-					first = codePoint;
-				} else {
-					const oldName = data[10];
-
-					if (/<control>/.test(name)) {
-						if (oldName !== "") {
-							utils.append(map, oldName, codePoint);
-						}
-					} else {
-						utils.append(map, name, codePoint);
-					}
-				}
+				utils.append(map, name, codePoint);
 			}
 		}
 	});

--- a/scripts/parse-name.js
+++ b/scripts/parse-name.js
@@ -34,7 +34,13 @@ const parseName = function(version) {
 					flag = true;
 					first = codePoint;
 				} else {
-					utils.append(map, name, codePoint);
+					const oldName = data[10];
+
+					if (/<control>/.test(name) && oldName !== "") {
+						utils.append(map, oldName, codePoint);
+					} else {
+						utils.append(map, name, codePoint);
+					}
 				}
 			}
 		}

--- a/scripts/parse-name.js
+++ b/scripts/parse-name.js
@@ -2,7 +2,7 @@
 
 const utils = require('./utils.js');
 
-const parseNames = function(version) {
+const parseName = function(version) {
 	const map = {};
 	const source = utils.readDataFile(version, 'database');
 	if (!source) {
@@ -43,4 +43,4 @@ const parseNames = function(version) {
 	return map;
 };
 
-module.exports = parseNames;
+module.exports = parseName;

--- a/scripts/parse-names.js
+++ b/scripts/parse-names.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const utils = require('./utils.js');
+
+const parseNames = function(version) {
+	const map = {};
+	const source = utils.readDataFile(version, 'database');
+	if (!source) {
+		return;
+	}
+	const lines = source.split('\n');
+
+	let flag = false;
+	let first = 0;
+	lines.forEach(function(line) {
+		const data = line.trim().split(';');
+		const codePoint = parseInt(data[0], 16);
+		const name = data[1];
+
+		if (!isNaN(codePoint)) {
+			if (flag) {
+				if (/<.+, Last>/.test(name)) {
+					flag = false;
+					const rangeName = /<(.+), Last>/.exec(name)[1];
+
+					utils.range(first, codePoint).forEach(function (value) {
+						utils.append(map, rangeName, value);
+					});
+				} else {
+					throw Error('Database exception');
+				}
+			} else {
+				if (/<.+, First>/.test(name)) {
+					flag = true;
+					first = codePoint;
+				} else {
+					utils.append(map, name, codePoint);
+				}
+			}
+		}
+	});
+
+	return map;
+};
+
+module.exports = parseNames;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -180,10 +180,17 @@ const readDataFile = function(version, type) {
 	return source;
 };
 
+const codePointToHex = function (codePoint) {
+	var hexString = codePoint.toString(16).toUpperCase();
+
+	return ('0000' + hexString).slice(-Math.max(4, hexString.length));
+};
+
 module.exports = {
 	'range': range,
 	'append': append,
 	'extend': extend,
 	'readDataFile': readDataFile,
-	'writeFiles': writeFiles
+	'writeFiles': writeFiles,
+	'codePointToHex': codePointToHex
 };

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -63,7 +63,7 @@ const writeFiles = function(options) {
 			type == 'Bidi_Class' ||
 			type == 'Bidi_Mirroring_Glyph' ||
 			type == 'Bidi_Paired_Bracket_Type' ||
-			type == 'Names' ||
+			type == 'Name' ||
 			(
 				type == 'General_Category' &&
 				// Use the most specific category names, i.e. those whose aliases match
@@ -79,7 +79,7 @@ const writeFiles = function(options) {
 				auxMap[type][codePoint] = item;
 			});
 		}
-		if (type == 'Bidi_Mirroring_Glyph' || type == 'Names') {
+		if (type == 'Bidi_Mirroring_Glyph' || type == 'Name') {
 			return;
 		}
 		append(dirMap, type, item);
@@ -130,7 +130,7 @@ const writeFiles = function(options) {
 		}
 		mkdirp.sync(dir);
 		let output = '';
-		if (/^(?:Bidi_Class|Bidi_Mirroring_Glyph|bidi-brackets|Names)$/.test(type)) {
+		if (/^(?:Bidi_Class|Bidi_Mirroring_Glyph|bidi-brackets|Name)$/.test(type)) {
 			const map = new Map();
 			Object.keys(auxMap[type]).forEach(function(key) {
 				const codePoint = Number(key);
@@ -140,7 +140,7 @@ const writeFiles = function(options) {
 			if ('Bidi_Mirroring_Glyph' == type) { // `Bidi_Mirroring_Glyph/index.js`
 				// Note: `Bidi_Mirroring_Glyph` doesn’t have repeated strings; don’t gzip.
 				output = `module.exports=${ jsesc(map) }`;
-			} else { // `Bidi_Class/index.js` or `bidi-brackets/index.js` or `Names/index.js`
+			} else { // `Bidi_Class/index.js` or `bidi-brackets/index.js` or `Name/index.js`
 				output = `module.exports=${ gzipInline(map) }`;
 			}
 		} else { // `categories/index.js`

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -63,6 +63,7 @@ const writeFiles = function(options) {
 			type == 'Bidi_Class' ||
 			type == 'Bidi_Mirroring_Glyph' ||
 			type == 'Bidi_Paired_Bracket_Type' ||
+			type == 'Names' ||
 			(
 				type == 'General_Category' &&
 				// Use the most specific category names, i.e. those whose aliases match
@@ -78,7 +79,7 @@ const writeFiles = function(options) {
 				auxMap[type][codePoint] = item;
 			});
 		}
-		if (type == 'Bidi_Mirroring_Glyph') {
+		if (type == 'Bidi_Mirroring_Glyph' || type == 'Names') {
 			return;
 		}
 		append(dirMap, type, item);
@@ -129,7 +130,7 @@ const writeFiles = function(options) {
 		}
 		mkdirp.sync(dir);
 		let output = '';
-		if (/^(?:Bidi_Class|Bidi_Mirroring_Glyph|bidi-brackets)$/.test(type)) {
+		if (/^(?:Bidi_Class|Bidi_Mirroring_Glyph|bidi-brackets|Names)$/.test(type)) {
 			const map = new Map();
 			Object.keys(auxMap[type]).forEach(function(key) {
 				const codePoint = Number(key);
@@ -139,7 +140,7 @@ const writeFiles = function(options) {
 			if ('Bidi_Mirroring_Glyph' == type) { // `Bidi_Mirroring_Glyph/index.js`
 				// Note: `Bidi_Mirroring_Glyph` doesn’t have repeated strings; don’t gzip.
 				output = `module.exports=${ jsesc(map) }`;
-			} else { // `Bidi_Class/index.js` or `bidi-brackets/index.js`
+			} else { // `Bidi_Class/index.js` or `bidi-brackets/index.js` or `Names/index.js`
 				output = `module.exports=${ gzipInline(map) }`;
 			}
 		} else { // `categories/index.js`


### PR DESCRIPTION
I have a couple use-cases where I need to look up the official name for code points. Rather than writing yet another Unicode parser, I thought you might be interested in adding this.

Right now, it maps everything in the PUA to "Private Use Area XX", but perhaps we should drop that (it isn't really a name). Let me know and I will change that.
