### PR TITLE
Fix types for `Case_Folding` and `Special_Casing` mappings

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -162,6 +162,8 @@ const writeFiles = function(options) {
 		// Save the data to a file
 		let codePointsExports = `require('./ranges.js').flatMap(r=>Array.from(r.keys()))`;
 		let symbolsExports = `require('./ranges.js').flatMap(r=>Array.from(r.values()))`;
+		let codePointsType = 'number[]';
+		let symbolsType = 'string[]';
 		if (!isCaseFoldingOrMapping) {
 			const encodedRanges = codePoints instanceof regenerate ? encodeRegenerate(codePoints) : encodeRanges(codePoints);
 			fs.writeFileSync(
@@ -198,6 +200,12 @@ const writeFiles = function(options) {
 			}
 			codePointsExports = codePoints.size < 10 ? jsesc(codePoints) : gzipInline(codePoints);
 			symbolsExports = codePoints.size < 10 ? jsesc(symbols) : gzipInline(symbols);
+			if ((type === 'Case_Folding' && item === 'F') || type === 'Special_Casing') {
+				codePointsType = 'Map<number, number[]>';
+			} else {
+				codePointsType = 'Map<number, number>';
+			}
+			symbolsType = 'Map<string, string>';
 		}
 		fs.writeFileSync(
 			path.resolve(dir, 'code-points.js'),
@@ -205,7 +213,7 @@ const writeFiles = function(options) {
 		);
 		fs.writeFileSync(
 			path.resolve(dir, 'code-points.d.ts'),
-			`declare const codePoints: number[];\nexport = codePoints;`
+			`declare const codePoints: ${ codePointsType };\nexport = codePoints;`
 		);
 		fs.writeFileSync(
 			path.resolve(dir, 'symbols.js'),
@@ -213,7 +221,7 @@ const writeFiles = function(options) {
 		);
 		fs.writeFileSync(
 			path.resolve(dir, 'symbols.d.ts'),
-			`declare const symbols: string[];\nexport = symbols;`
+			`declare const symbols: ${ symbolsType };\nexport = symbols;`
 		);
 	});
 	if (options.type == 'Bidi_Mirroring_Glyph') {


### PR DESCRIPTION
`Special_Casing` uses `Map<number, number[]>`

https://github.com/node-unicode/node-unicode-data/blob/d03bce2370bc95c5ae7e347363b38f242fc09b43/scripts/parse-special-casing.js#L39-L40

https://github.com/node-unicode/node-unicode-data/blob/d03bce2370bc95c5ae7e347363b38f242fc09b43/scripts/parse-special-casing.js#L24

`Case_Folding` uses `Map<number, number[]>` for full case folding (it's always one-to-many mapping). `Map<number, number>` for common, simple and special case foldings foldings (which are guaranteed to be one-to-one mappings).

https://github.com/node-unicode/node-unicode-data/blob/d03bce2370bc95c5ae7e347363b38f242fc09b43/scripts/parse-case-folding.js#L25-L28